### PR TITLE
Removed Top Bar and added Phosphorus loading

### DIFF
--- a/originals/GRA0007/scratchultimate.user.js
+++ b/originals/GRA0007/scratchultimate.user.js
@@ -8,13 +8,27 @@
 // @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant        none
 // ==/UserScript==
-
 if(document.URL.indexOf("mystuff/") >= 0){ 
     waitForKeyElements ("#tabs", appendSidebarItems);
 }
 
-if(document.URL.indexOf("users/") >= 0){ 
+if(document.URL.indexOf("users/") >= 0){
     waitForKeyElements ("#featured-project", liveFeaturedProject);
+}
+
+function appendSidebarItems(jNode) {
+    jNode.append( "<li data-tab='myTopics'><a href='http://scratch.mit.edu/discuss/search/?action=show_user&show_as=topics'>My Topics</a></li>" );
+}
+
+function liveFeaturedProject(jNode) {
+    var $projName = $('.project-name'),
+        projID = Scratch.INIT_DATA.PROFILE.featuredProject.id;
+    $('.player .title').css('text-align', 'center');
+    $projName.html($projName.html().trim()); //Make sure no whitespaces interefere with centering
+    
+    jNode.remove();
+    
+    $( ".stage" ).append( "<div style='overflow: hidden; height: 216px;' id='applet'><iframe style='margin-top: -25px;' allowtransparency='true' width='282' height='237' frameborder='0' allowfullscreen=''></iframe></div>" );
     
     $('.stage iframe').load(function(){
         var is404 = $(this).contents().find('#page-404').length > 0;
@@ -25,23 +39,8 @@ if(document.URL.indexOf("users/") >= 0){
         	$(this).attr('src', 'http://phosphorus.github.io/app.html?id=' + projID);
         }
         else if($(this).attr('src').indexOf('http://scratch.mit.edu/projects/embed/') > -1) {
-            setTimeout(function(){$('.stage iframe').attr('height', '238')}, 200);
+            setTimeout(function(){$('.stage iframe').attr('height', '238');}, 200);
         }
     });
     $('.stage iframe').attr("src", "http://scratch.mit.edu/projects/embed/" + projID + "/?autostart=true");
-}
-
-function appendSidebarItems(jNode) {
-    jNode.append( "<li data-tab='myTopics'><a href='http://scratch.mit.edu/discuss/search/?action=show_user&show_as=topics'>My Topics</a></li>" );
-}
-
-function liveFeaturedProject(jNode) {
-    var $projName = $('.project-name');
-    $('.player .title').css('text-align', 'center');
-    $projName.html($projName.html().trim()); //Make sure no whitespaces interefere with centering
-    
-    jNode.remove();
-    projID = Scratch.INIT_DATA.PROFILE.featuredProject.id;
-    
-    $( ".stage" ).append( "<div style='overflow: hidden; height: 216px;' id='applet'><iframe style='margin-top: -25px;' allowtransparency='true' width='282' height='237' frameborder='0' allowfullscreen=''></iframe></div>" );
 }

--- a/originals/GRA0007/scratchultimate.user.js
+++ b/originals/GRA0007/scratchultimate.user.js
@@ -3,16 +3,22 @@
 // @version      0.2.1
 // @description  Useful Stuff
 // @author       GRA0007
+// @contributor  TheGameBuilder
 // @match        http://scratch.mit.edu/*
 // @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant        none
 // ==/UserScript==
+var $projName = $('.project-name');
+$('.player .title').css('text-align', 'center');
+$projName.html($projName.html().trim()); //Make sure no whitespaces interefere with centering
+
 if(document.URL.indexOf("mystuff/") >= 0){ 
     waitForKeyElements ("#tabs", appendSidebarItems);
 }
 
 if(document.URL.indexOf("users/") >= 0){ 
     waitForKeyElements ("#featured-project", liveFeaturedProject);
+    
     $('.stage iframe').load(function(){
         var is404 = $(this).contents().find('#page-404').length > 0;
         if(is404) {
@@ -22,7 +28,7 @@ if(document.URL.indexOf("users/") >= 0){
         	$(this).attr('src', 'http://phosphorus.github.io/app.html?id=' + projID);
         }
         else if($(this).attr('src').indexOf('http://scratch.mit.edu/projects/embed/') > -1) {
-            setTimeout(function(){$('.stage iframe').attr('height', '238')}, 100);
+            setTimeout(function(){$('.stage iframe').attr('height', '238')}, 200);
         }
     });
     $('.stage iframe').attr("src", "http://scratch.mit.edu/projects/embed/" + projID + "/?autostart=true");

--- a/originals/GRA0007/scratchultimate.user.js
+++ b/originals/GRA0007/scratchultimate.user.js
@@ -7,13 +7,25 @@
 // @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant        none
 // ==/UserScript==
-
 if(document.URL.indexOf("mystuff/") >= 0){ 
     waitForKeyElements ("#tabs", appendSidebarItems);
 }
 
 if(document.URL.indexOf("users/") >= 0){ 
     waitForKeyElements ("#featured-project", liveFeaturedProject);
+    $('.stage iframe').load(function(){
+        var is404 = $(this).contents().find('#page-404').length > 0;
+        if(is404) {
+            $('.stage div').css('height', '211px');
+            $(this).css('margin-top', '-14px');
+            $(this).attr('height', '239');
+        	$(this).attr('src', 'http://phosphorus.github.io/app.html?id=' + projID);
+        }
+        else if($(this).attr('src').indexOf('http://scratch.mit.edu/projects/embed/') > -1) {
+            setTimeout(function(){$('.stage iframe').attr('height', '238')}, 100);
+        }
+    });
+    $('.stage iframe').attr("src", "http://scratch.mit.edu/projects/embed/" + projID + "/?autostart=true");
 }
 
 function appendSidebarItems(jNode) {
@@ -22,7 +34,8 @@ function appendSidebarItems(jNode) {
 
 function liveFeaturedProject(jNode) {
     jNode.remove();
-    var projID = Scratch.INIT_DATA.PROFILE.featuredProject.id
-    var usid = Scratch.INIT_DATA.PROFILE.featuredProject.creator
-    $( ".stage" ).append( "<iframe allowtransparency='true' width='282' height='210' src='http://scratch.mit.edu/projects/embed/" + projID + "/?autostart=true' frameborder='0' allowfullscreen=''></iframe>" );
+    projID = Scratch.INIT_DATA.PROFILE.featuredProject.id;
+    usid = Scratch.INIT_DATA.PROFILE.featuredProject.creator;
+    
+    $( ".stage" ).append( "<div style='overflow: hidden; height: 216px;' id='applet'><iframe style='margin-top: -25px;' allowtransparency='true' width='282' height='237' frameborder='0' allowfullscreen=''></iframe></div>" );
 }

--- a/originals/GRA0007/scratchultimate.user.js
+++ b/originals/GRA0007/scratchultimate.user.js
@@ -8,9 +8,6 @@
 // @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant        none
 // ==/UserScript==
-var $projName = $('.project-name');
-$('.player .title').css('text-align', 'center');
-$projName.html($projName.html().trim()); //Make sure no whitespaces interefere with centering
 
 if(document.URL.indexOf("mystuff/") >= 0){ 
     waitForKeyElements ("#tabs", appendSidebarItems);
@@ -39,9 +36,12 @@ function appendSidebarItems(jNode) {
 }
 
 function liveFeaturedProject(jNode) {
+    var $projName = $('.project-name');
+    $('.player .title').css('text-align', 'center');
+    $projName.html($projName.html().trim()); //Make sure no whitespaces interefere with centering
+    
     jNode.remove();
     projID = Scratch.INIT_DATA.PROFILE.featuredProject.id;
-    usid = Scratch.INIT_DATA.PROFILE.featuredProject.creator;
     
     $( ".stage" ).append( "<div style='overflow: hidden; height: 216px;' id='applet'><iframe style='margin-top: -25px;' allowtransparency='true' width='282' height='237' frameborder='0' allowfullscreen=''></iframe></div>" );
 }


### PR DESCRIPTION
Featured projects now automatically load with Phosphorus if iFrame page yields 404 (unshared and deleted projects).
Project's top bar is now hidden as to leave more room for the project.

PS: The css and height attribute changes are to work around a glitch that cuts off the bottom of the iFrame.